### PR TITLE
RBAC fix and apiGroups correction

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: aws-iam-controller-manager
   namespace: system
 spec:
   template:

--- a/config/rbac/assumerolepolicy_editor_role.yaml
+++ b/config/rbac/assumerolepolicy_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: assumerolepolicy-editor-role
 rules:
 - apiGroups:
-  - iam.redradrat.xyz
+  - aws-iam.redradrat.xyz
   resources:
   - assumerolepolicies
   verbs:
@@ -17,7 +17,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - iam.redradrat.xyz
+  - aws-iam.redradrat.xyz
   resources:
   - assumerolepolicies/status
   verbs:

--- a/config/rbac/assumerolepolicy_viewer_role.yaml
+++ b/config/rbac/assumerolepolicy_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: assumerolepolicy-viewer-role
 rules:
 - apiGroups:
-  - iam.redradrat.xyz
+  - aws-iam.redradrat.xyz
   resources:
   - assumerolepolicies
   verbs:
@@ -13,7 +13,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - iam.redradrat.xyz
+  - aws-iam.redradrat.xyz
   resources:
   - assumerolepolicies/status
   verbs:

--- a/config/rbac/policyattachment_editor_role.yaml
+++ b/config/rbac/policyattachment_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: policyattachment-editor-role
 rules:
 - apiGroups:
-  - iam.redradrat.xyz
+  - aws-iam.redradrat.xyz
   resources:
   - policyattachments
   verbs:
@@ -17,7 +17,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - iam.redradrat.xyz
+  - aws-iam.redradrat.xyz
   resources:
   - policyattachments/status
   verbs:

--- a/config/rbac/policyattachment_viewer_role.yaml
+++ b/config/rbac/policyattachment_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: policyattachment-viewer-role
 rules:
 - apiGroups:
-  - iam.redradrat.xyz
+  - aws-iam.redradrat.xyz
   resources:
   - policyattachments
   verbs:
@@ -13,7 +13,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - iam.redradrat.xyz
+  - aws-iam.redradrat.xyz
   resources:
   - policyattachments/status
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -25,7 +25,27 @@ rules:
   verbs:
   - get
   - patch
+  - update 
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
   - update
+  - watch
+- apiGroups:
+  - ""  
+  resources:
+  - serviceaccounts/status
+  verbs:
+  - get
+  - patch
+  - update  
 - apiGroups:
   - aws-iam.redradrat.xyz
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,7 +6,9 @@ metadata:
   creationTimestamp: null
   name: manager-role
 rules:
-- resources:
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create
@@ -16,7 +18,9 @@ rules:
   - patch
   - update
   - watch
-- resources:
+- apiGroups:
+  - "" 
+  resources:
   - secrets/status
   verbs:
   - get
@@ -103,9 +107,9 @@ rules:
   - patch
   - update
 - apiGroups:
-  - iam.redradrat.xyz
+  - aws-iam.redradrat.xyz
   resources:
-  - policyassignments
+  - policyattachments
   verbs:
   - create
   - delete
@@ -115,25 +119,29 @@ rules:
   - update
   - watch
 - apiGroups:
-  - iam.redradrat.xyz
+  - aws-iam.redradrat.xyz
   resources:
-  - policyassignments/status
+  - policyattachments/status
   verbs:
   - get
   - patch
   - update
 - apiGroups:
-  - iam.redradrat.xyz
+  - aws-iam.redradrat.xyz
   resources:
-  - users
+  - assumerolepolicies
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
-  - iam.redradrat.xyz
+  - aws-iam.redradrat.xyz
   resources:
-  - users/status
+  - assumerolepolicies/status
   verbs:
   - get
   - patch


### PR DESCRIPTION
RBAC Fix:
**1. manager-role**
- Added apiGroups: “” for `secret` and `secret/status`
- Removed policyassignment and added policyattachments rules 
- Added rule for assumerolepolicies

**2. apiGroups correction**
Changed apigroups from `iam.redradrat.xyz` to `aws-iam.redradrat.xyz` for following roles :
- assumerolepolicy-editor-role
- assumerolepolicy-viewer-role
- policyattachment-editor-role
- policyattachment-viewer-role

**3. Deployment name correction** in manager_auth_proxy_patch.yaml 