### PR TITLE
updated CRD and ClusterRole API for k8s v1.22

### DIFF
--- a/config/crd/bases/aws-iam.redradrat.xyz_assumerolepolicies.yaml
+++ b/config/crd/bases/aws-iam.redradrat.xyz_assumerolepolicies.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,77 +15,76 @@ spec:
     plural: assumerolepolicies
     singular: assumerolepolicy
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: AssumeRolePolicy is the Schema for the assumerolepolicies API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: AssumeRolePolicySpec defines the desired state of AssumeRolePolicy
-          properties:
-            statement:
-              description: Statements holds the list of all the policy statement entries
-              items:
-                properties:
-                  actions:
-                    description: Actions holds the desired effect the statement should
-                      ensure
-                    items:
-                      type: string
-                    type: array
-                  conditions:
-                    additionalProperties:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    description: Conditions specifies the circumstances under which
-                      the policy grants permission
-                    type: object
-                  effect:
-                    description: Effect holds the desired effect the statement should
-                      ensure
-                    type: string
-                  principal:
-                    additionalProperties:
-                      type: string
-                    description: Principal denotes an account, user, role, or federated
-                      user to which you would like to allow or deny access with a
-                      resource-based policy
-                    type: object
-                  resources:
-                    description: Resources denotes an a list of resources to which
-                      the actions apply. If you do not set this value, then the resource
-                      to which the action applies is the resource to which the policy
-                      is attached to
-                    items:
-                      type: string
-                    type: array
-                  sid:
-                    description: Sid is an optional Statement ID to identify a Statement
-                    type: string
-                type: object
-              type: array
-          type: object
-        status:
-          description: AssumeRolePolicyStatus defines the observed state of AssumeRolePolicy
-          type: object
-      type: object
-  version: v1beta1
   versions:
   - name: v1beta1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        description: AssumeRolePolicy is the Schema for the assumerolepolicies API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AssumeRolePolicySpec defines the desired state of AssumeRolePolicy
+            properties:
+              statement:
+                description: Statements holds the list of all the policy statement entries
+                items:
+                  properties:
+                    actions:
+                      description: Actions holds the desired effect the statement should
+                        ensure
+                      items:
+                        type: string
+                      type: array
+                    conditions:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      description: Conditions specifies the circumstances under which
+                        the policy grants permission
+                      type: object
+                    effect:
+                      description: Effect holds the desired effect the statement should
+                        ensure
+                      type: string
+                    principal:
+                      additionalProperties:
+                        type: string
+                      description: Principal denotes an account, user, role, or federated
+                        user to which you would like to allow or deny access with a
+                        resource-based policy
+                      type: object
+                    resources:
+                      description: Resources denotes an a list of resources to which
+                        the actions apply. If you do not set this value, then the resource
+                        to which the action applies is the resource to which the policy
+                        is attached to
+                      items:
+                        type: string
+                      type: array
+                    sid:
+                      description: Sid is an optional Statement ID to identify a Statement
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: AssumeRolePolicyStatus defines the observed state of AssumeRolePolicy
+            type: object
+        type: object
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/aws-iam.redradrat.xyz_groups.yaml
+++ b/config/crd/bases/aws-iam.redradrat.xyz_groups.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,19 +8,6 @@ metadata:
   creationTimestamp: null
   name: groups.aws-iam.redradrat.xyz
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.arn
-    name: ARN
-    type: string
-  - JSONPath: .status.message
-    name: Message
-    type: string
-  - JSONPath: .status.state
-    name: Status
-    type: string
-  - JSONPath: .status.lastSyncAttempt
-    name: Last Sync
-    type: string
   group: aws-iam.redradrat.xyz
   names:
     kind: Group
@@ -30,101 +17,113 @@ spec:
     - iamgroup
     singular: group
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Group is the Schema for the roles API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: GroupSpec defines the desired state of Group
-          properties:
-            users:
-              description: Users holds the list of all Users to be added the group
-              items:
-                description: ObjectReference contains enough information to let you
-                  inspect or modify the referred object.
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-              type: array
-          type: object
-        status:
-          properties:
-            arn:
-              description: Arn holds the concrete AWS ARN of the managed policy
-              type: string
-            lastSyncAttempt:
-              description: LastSyncTime holds the timestamp of the last sync attempt
-              type: string
-            message:
-              description: Message holds the current/last status message from the
-                operator.
-              type: string
-            observedGeneration:
-              description: ObservedGeneration holds the generation (metadata.generation
-                in CR) observed by the controller
-              format: int64
-              type: integer
-            state:
-              description: State holds the current state of the resource
-              type: string
-          required:
-          - arn
-          - lastSyncAttempt
-          - message
-          - observedGeneration
-          - state
-          type: object
-      type: object
-  version: v1beta1
   versions:
   - name: v1beta1
     served: true
     storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - jsonPath: .status.arn
+      name: ARN
+      type: string
+    - jsonPath: .status.message
+      name: Message
+      type: string
+    - jsonPath: .status.state
+      name: Status
+      type: string
+    - jsonPath: .status.lastSyncAttempt
+      name: Last Sync
+      type: string
+    schema:
+      openAPIV3Schema:
+        description: Group is the Schema for the roles API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GroupSpec defines the desired state of Group
+            properties:
+              users:
+                description: Users holds the list of all Users to be added the group
+                items:
+                  description: ObjectReference contains enough information to let you
+                    inspect or modify the referred object.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            properties:
+              arn:
+                description: Arn holds the concrete AWS ARN of the managed policy
+                type: string
+              lastSyncAttempt:
+                description: LastSyncTime holds the timestamp of the last sync attempt
+                type: string
+              message:
+                description: Message holds the current/last status message from the
+                  operator.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration holds the generation (metadata.generation
+                  in CR) observed by the controller
+                format: int64
+                type: integer
+              state:
+                description: State holds the current state of the resource
+                type: string
+            required:
+            - arn
+            - lastSyncAttempt
+            - message
+            - observedGeneration
+            - state
+            type: object
+        type: object
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/aws-iam.redradrat.xyz_policies.yaml
+++ b/config/crd/bases/aws-iam.redradrat.xyz_policies.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,19 +8,6 @@ metadata:
   creationTimestamp: null
   name: policies.aws-iam.redradrat.xyz
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.arn
-    name: ARN
-    type: string
-  - JSONPath: .status.message
-    name: Message
-    type: string
-  - JSONPath: .status.state
-    name: Status
-    type: string
-  - JSONPath: .status.lastSyncAttempt
-    name: Last Sync
-    type: string
   group: aws-iam.redradrat.xyz
   names:
     kind: Policy
@@ -30,99 +17,111 @@ spec:
     - iampolicy
     singular: policy
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Policy is the Schema for the policies API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: PolicySpec defines the desired state of Policy
-          properties:
-            description:
-              description: Description holds the description string for the Role
-              type: string
-            statement:
-              description: Statements holds the list of all the policy statement entries
-              items:
-                properties:
-                  actions:
-                    description: Actions holds the desired effect the statement should
-                      ensure
-                    items:
-                      type: string
-                    type: array
-                  conditions:
-                    additionalProperties:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    description: Conditions specifies the circumstances under which
-                      the policy grants permission
-                    type: object
-                  effect:
-                    description: Effect holds the desired effect the statement should
-                      ensure
-                    type: string
-                  resources:
-                    description: Resources denotes an a list of resources to which
-                      the actions apply. If you do not set this value, then the resource
-                      to which the action applies is the resource to which the policy
-                      is attached to
-                    items:
-                      type: string
-                    type: array
-                  sid:
-                    description: Sid is an optional Statement ID to identify a Statement
-                    type: string
-                type: object
-              type: array
-          type: object
-        status:
-          properties:
-            arn:
-              description: Arn holds the concrete AWS ARN of the managed policy
-              type: string
-            lastSyncAttempt:
-              description: LastSyncTime holds the timestamp of the last sync attempt
-              type: string
-            message:
-              description: Message holds the current/last status message from the
-                operator.
-              type: string
-            observedGeneration:
-              description: ObservedGeneration holds the generation (metadata.generation
-                in CR) observed by the controller
-              format: int64
-              type: integer
-            state:
-              description: State holds the current state of the resource
-              type: string
-          required:
-          - arn
-          - lastSyncAttempt
-          - message
-          - observedGeneration
-          - state
-          type: object
-      type: object
-  version: v1beta1
   versions:
   - name: v1beta1
     served: true
     storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - jsonPath: .status.arn
+      name: ARN
+      type: string
+    - jsonPath: .status.message
+      name: Message
+      type: string
+    - jsonPath: .status.state
+      name: Status
+      type: string
+    - jsonPath: .status.lastSyncAttempt
+      name: Last Sync
+      type: string
+    schema:
+      openAPIV3Schema:
+        description: Policy is the Schema for the policies API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicySpec defines the desired state of Policy
+            properties:
+              description:
+                description: Description holds the description string for the Role
+                type: string
+              statement:
+                description: Statements holds the list of all the policy statement entries
+                items:
+                  properties:
+                    actions:
+                      description: Actions holds the desired effect the statement should
+                        ensure
+                      items:
+                        type: string
+                      type: array
+                    conditions:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      description: Conditions specifies the circumstances under which
+                        the policy grants permission
+                      type: object
+                    effect:
+                      description: Effect holds the desired effect the statement should
+                        ensure
+                      type: string
+                    resources:
+                      description: Resources denotes an a list of resources to which
+                        the actions apply. If you do not set this value, then the resource
+                        to which the action applies is the resource to which the policy
+                        is attached to
+                      items:
+                        type: string
+                      type: array
+                    sid:
+                      description: Sid is an optional Statement ID to identify a Statement
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            properties:
+              arn:
+                description: Arn holds the concrete AWS ARN of the managed policy
+                type: string
+              lastSyncAttempt:
+                description: LastSyncTime holds the timestamp of the last sync attempt
+                type: string
+              message:
+                description: Message holds the current/last status message from the
+                  operator.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration holds the generation (metadata.generation
+                  in CR) observed by the controller
+                format: int64
+                type: integer
+              state:
+                description: State holds the current state of the resource
+                type: string
+            required:
+            - arn
+            - lastSyncAttempt
+            - message
+            - observedGeneration
+            - state
+            type: object
+        type: object
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/aws-iam.redradrat.xyz_policyattachments.yaml
+++ b/config/crd/bases/aws-iam.redradrat.xyz_policyattachments.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,19 +8,6 @@ metadata:
   creationTimestamp: null
   name: policyattachments.aws-iam.redradrat.xyz
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.arn
-    name: ARN
-    type: string
-  - JSONPath: .status.message
-    name: Message
-    type: string
-  - JSONPath: .status.state
-    name: Status
-    type: string
-  - JSONPath: .status.lastSyncAttempt
-    name: Last Sync
-    type: string
   group: aws-iam.redradrat.xyz
   names:
     kind: PolicyAttachment
@@ -30,82 +17,94 @@ spec:
     - iampolicyattachment
     singular: policyattachment
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: PolicyAttachment is the Schema for the policyattachments API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: PolicyAttachmentSpec defines the desired state of PolicyAttachment
-          properties:
-            policy:
-              description: PolicyReference refrences the Policy resource to attach
-                to another resource
-              properties:
-                name:
-                  type: string
-                namespace:
-                  type: string
-              type: object
-            target:
-              description: Attachments holds all defined attachments
-              properties:
-                name:
-                  type: string
-                namespace:
-                  type: string
-                type:
-                  description: Type specifies the target type of the Refrence e.g.
-                    User/Role/Group
-                  type: string
-              type: object
-          type: object
-        status:
-          properties:
-            arn:
-              description: Arn holds the concrete AWS ARN of the managed policy
-              type: string
-            lastSyncAttempt:
-              description: LastSyncTime holds the timestamp of the last sync attempt
-              type: string
-            message:
-              description: Message holds the current/last status message from the
-                operator.
-              type: string
-            observedGeneration:
-              description: ObservedGeneration holds the generation (metadata.generation
-                in CR) observed by the controller
-              format: int64
-              type: integer
-            state:
-              description: State holds the current state of the resource
-              type: string
-          required:
-          - arn
-          - lastSyncAttempt
-          - message
-          - observedGeneration
-          - state
-          type: object
-      type: object
-  version: v1beta1
   versions:
   - name: v1beta1
     served: true
     storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - jsonPath: .status.arn
+      name: ARN
+      type: string
+    - jsonPath: .status.message
+      name: Message
+      type: string
+    - jsonPath: .status.state
+      name: Status
+      type: string
+    - jsonPath: .status.lastSyncAttempt
+      name: Last Sync
+      type: string
+    schema:
+      openAPIV3Schema:
+        description: PolicyAttachment is the Schema for the policyattachments API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicyAttachmentSpec defines the desired state of PolicyAttachment
+            properties:
+              policy:
+                description: PolicyReference refrences the Policy resource to attach
+                  to another resource
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                type: object
+              target:
+                description: Attachments holds all defined attachments
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  type:
+                    description: Type specifies the target type of the Refrence e.g.
+                      User/Role/Group
+                    type: string
+                type: object
+            type: object
+          status:
+            properties:
+              arn:
+                description: Arn holds the concrete AWS ARN of the managed policy
+                type: string
+              lastSyncAttempt:
+                description: LastSyncTime holds the timestamp of the last sync attempt
+                type: string
+              message:
+                description: Message holds the current/last status message from the
+                  operator.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration holds the generation (metadata.generation
+                  in CR) observed by the controller
+                format: int64
+                type: integer
+              state:
+                description: State holds the current state of the resource
+                type: string
+            required:
+            - arn
+            - lastSyncAttempt
+            - message
+            - observedGeneration
+            - state
+            type: object
+        type: object
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/aws-iam.redradrat.xyz_roles.yaml
+++ b/config/crd/bases/aws-iam.redradrat.xyz_roles.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,19 +8,6 @@ metadata:
   creationTimestamp: null
   name: roles.aws-iam.redradrat.xyz
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.arn
-    name: ARN
-    type: string
-  - JSONPath: .status.message
-    name: Message
-    type: string
-  - JSONPath: .status.state
-    name: Status
-    type: string
-  - JSONPath: .status.lastSyncAttempt
-    name: Last Sync
-    type: string
   group: aws-iam.redradrat.xyz
   names:
     kind: Role
@@ -30,129 +17,141 @@ spec:
     - iamrole
     singular: role
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Role is the Schema for the roles API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: RoleSpec defines the desired state of Role
-          properties:
-            assumeRolePolicy:
-              description: AssumeRolePolicy holds the Trust Policy statement for the
-                role
-              items:
-                properties:
-                  actions:
-                    description: Actions holds the desired effect the statement should
-                      ensure
-                    items:
-                      type: string
-                    type: array
-                  conditions:
-                    additionalProperties:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    description: Conditions specifies the circumstances under which
-                      the policy grants permission
-                    type: object
-                  effect:
-                    description: Effect holds the desired effect the statement should
-                      ensure
-                    type: string
-                  principal:
-                    additionalProperties:
-                      type: string
-                    description: Principal denotes an account, user, role, or federated
-                      user to which you would like to allow or deny access with a
-                      resource-based policy
-                    type: object
-                  resources:
-                    description: Resources denotes an a list of resources to which
-                      the actions apply. If you do not set this value, then the resource
-                      to which the action applies is the resource to which the policy
-                      is attached to
-                    items:
-                      type: string
-                    type: array
-                  sid:
-                    description: Sid is an optional Statement ID to identify a Statement
-                    type: string
-                type: object
-              type: array
-            assumeRolePolicyRef:
-              description: AssumeRolePolicyReference references a Policy resource
-                to use as AssumeRolePolicy
-              properties:
-                name:
-                  type: string
-                namespace:
-                  type: string
-              type: object
-            createServiceAccount:
-              description: CreateServiceAccount triggers the creation of an annotated
-                ServiceAccount for the created role
-              type: boolean
-            description:
-              description: Description holds the description string for the Role
-              type: string
-            maxSessionDuration:
-              description: MaxSessionDuration specifies the maximum duration a session
-                with this role assumed can last
-              format: int64
-              nullable: true
-              type: integer
-          type: object
-        status:
-          properties:
-            ReadAssumeRolePolicyVersion:
-              type: string
-            arn:
-              description: Arn holds the concrete AWS ARN of the managed policy
-              type: string
-            lastSyncAttempt:
-              description: LastSyncTime holds the timestamp of the last sync attempt
-              type: string
-            message:
-              description: Message holds the current/last status message from the
-                operator.
-              type: string
-            observedGeneration:
-              description: ObservedGeneration holds the generation (metadata.generation
-                in CR) observed by the controller
-              format: int64
-              type: integer
-            state:
-              description: State holds the current state of the resource
-              type: string
-          required:
-          - ReadAssumeRolePolicyVersion
-          - arn
-          - lastSyncAttempt
-          - message
-          - observedGeneration
-          - state
-          type: object
-      type: object
-  version: v1beta1
   versions:
   - name: v1beta1
     served: true
     storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - jsonPath: .status.arn
+      name: ARN
+      type: string
+    - jsonPath: .status.message
+      name: Message
+      type: string
+    - jsonPath: .status.state
+      name: Status
+      type: string
+    - jsonPath: .status.lastSyncAttempt
+      name: Last Sync
+      type: string
+    schema:
+      openAPIV3Schema:
+        description: Role is the Schema for the roles API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RoleSpec defines the desired state of Role
+            properties:
+              assumeRolePolicy:
+                description: AssumeRolePolicy holds the Trust Policy statement for the
+                  role
+                items:
+                  properties:
+                    actions:
+                      description: Actions holds the desired effect the statement should
+                        ensure
+                      items:
+                        type: string
+                      type: array
+                    conditions:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      description: Conditions specifies the circumstances under which
+                        the policy grants permission
+                      type: object
+                    effect:
+                      description: Effect holds the desired effect the statement should
+                        ensure
+                      type: string
+                    principal:
+                      additionalProperties:
+                        type: string
+                      description: Principal denotes an account, user, role, or federated
+                        user to which you would like to allow or deny access with a
+                        resource-based policy
+                      type: object
+                    resources:
+                      description: Resources denotes an a list of resources to which
+                        the actions apply. If you do not set this value, then the resource
+                        to which the action applies is the resource to which the policy
+                        is attached to
+                      items:
+                        type: string
+                      type: array
+                    sid:
+                      description: Sid is an optional Statement ID to identify a Statement
+                      type: string
+                  type: object
+                type: array
+              assumeRolePolicyRef:
+                description: AssumeRolePolicyReference references a Policy resource
+                  to use as AssumeRolePolicy
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                type: object
+              createServiceAccount:
+                description: CreateServiceAccount triggers the creation of an annotated
+                  ServiceAccount for the created role
+                type: boolean
+              description:
+                description: Description holds the description string for the Role
+                type: string
+              maxSessionDuration:
+                description: MaxSessionDuration specifies the maximum duration a session
+                  with this role assumed can last
+                format: int64
+                nullable: true
+                type: integer
+            type: object
+          status:
+            properties:
+              ReadAssumeRolePolicyVersion:
+                type: string
+              arn:
+                description: Arn holds the concrete AWS ARN of the managed policy
+                type: string
+              lastSyncAttempt:
+                description: LastSyncTime holds the timestamp of the last sync attempt
+                type: string
+              message:
+                description: Message holds the current/last status message from the
+                  operator.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration holds the generation (metadata.generation
+                  in CR) observed by the controller
+                format: int64
+                type: integer
+              state:
+                description: State holds the current state of the resource
+                type: string
+            required:
+            - ReadAssumeRolePolicyVersion
+            - arn
+            - lastSyncAttempt
+            - message
+            - observedGeneration
+            - state
+            type: object
+        type: object
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/aws-iam.redradrat.xyz_users.yaml
+++ b/config/crd/bases/aws-iam.redradrat.xyz_users.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,19 +8,6 @@ metadata:
   creationTimestamp: null
   name: users.aws-iam.redradrat.xyz
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.arn
-    name: ARN
-    type: string
-  - JSONPath: .status.message
-    name: Message
-    type: string
-  - JSONPath: .status.state
-    name: Status
-    type: string
-  - JSONPath: .status.lastSyncAttempt
-    name: Last Sync
-    type: string
   group: aws-iam.redradrat.xyz
   names:
     kind: User
@@ -30,103 +17,115 @@ spec:
     - iamuser
     singular: user
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: User is the Schema for the users API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: UserSpec defines the desired state of User
-          properties:
-            createLoginProfile:
-              description: CreateLoginProfile triggers the creation of Login Profile
-                in AWS and creates a user/pass secret
-              type: boolean
-            createProgrammaticAccess:
-              description: CreateProgrammaticAccess triggers the creation of API creds
-                in AWS and creates a cred secret
-              type: boolean
-          type: object
-        status:
-          properties:
-            arn:
-              description: Arn holds the concrete AWS ARN of the managed policy
-              type: string
-            lastSyncAttempt:
-              description: LastSyncTime holds the timestamp of the last sync attempt
-              type: string
-            loginProfileCreated:
-              description: LoginProfileCreated holds info about whether or not a LoginProfile
-                has been created for this user
-              type: boolean
-            loginProfileSecret:
-              description: LoginProfileSecret holds the reference to the created LoginProfile
-                Secret
-              properties:
-                name:
-                  description: Name is unique within a namespace to reference a secret
-                    resource.
-                  type: string
-                namespace:
-                  description: Namespace defines the space within which the secret
-                    name must be unique.
-                  type: string
-              type: object
-            message:
-              description: Message holds the current/last status message from the
-                operator.
-              type: string
-            observedGeneration:
-              description: ObservedGeneration holds the generation (metadata.generation
-                in CR) observed by the controller
-              format: int64
-              type: integer
-            programmaticAccessCreated:
-              description: ProgrammaticAccessCreated holds info about whether or not
-                programmatic access credentials have been created for this user
-              type: boolean
-            programmaticAccessSecret:
-              description: ProgrammaticAccessSecret holds the reference to the created
-                LoginProfile Secret
-              properties:
-                name:
-                  description: Name is unique within a namespace to reference a secret
-                    resource.
-                  type: string
-                namespace:
-                  description: Namespace defines the space within which the secret
-                    name must be unique.
-                  type: string
-              type: object
-            state:
-              description: State holds the current state of the resource
-              type: string
-          required:
-          - arn
-          - lastSyncAttempt
-          - message
-          - observedGeneration
-          - state
-          type: object
-      type: object
-  version: v1beta1
   versions:
   - name: v1beta1
     served: true
     storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - jsonPath: .status.arn
+      name: ARN
+      type: string
+    - jsonPath: .status.message
+      name: Message
+      type: string
+    - jsonPath: .status.state
+      name: Status
+      type: string
+    - jsonPath: .status.lastSyncAttempt
+      name: Last Sync
+      type: string
+    schema:
+      openAPIV3Schema:
+        description: User is the Schema for the users API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: UserSpec defines the desired state of User
+            properties:
+              createLoginProfile:
+                description: CreateLoginProfile triggers the creation of Login Profile
+                  in AWS and creates a user/pass secret
+                type: boolean
+              createProgrammaticAccess:
+                description: CreateProgrammaticAccess triggers the creation of API creds
+                  in AWS and creates a cred secret
+                type: boolean
+            type: object
+          status:
+            properties:
+              arn:
+                description: Arn holds the concrete AWS ARN of the managed policy
+                type: string
+              lastSyncAttempt:
+                description: LastSyncTime holds the timestamp of the last sync attempt
+                type: string
+              loginProfileCreated:
+                description: LoginProfileCreated holds info about whether or not a LoginProfile
+                  has been created for this user
+                type: boolean
+              loginProfileSecret:
+                description: LoginProfileSecret holds the reference to the created LoginProfile
+                  Secret
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a secret
+                      resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+              message:
+                description: Message holds the current/last status message from the
+                  operator.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration holds the generation (metadata.generation
+                  in CR) observed by the controller
+                format: int64
+                type: integer
+              programmaticAccessCreated:
+                description: ProgrammaticAccessCreated holds info about whether or not
+                  programmatic access credentials have been created for this user
+                type: boolean
+              programmaticAccessSecret:
+                description: ProgrammaticAccessSecret holds the reference to the created
+                  LoginProfile Secret
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a secret
+                      resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+              state:
+                description: State holds the current state of the resource
+                type: string
+            required:
+            - arn
+            - lastSyncAttempt
+            - message
+            - observedGeneration
+            - state
+            type: object
+        type: object
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/patches/cainjection_in_assumerolepolicies.yaml
+++ b/config/crd/patches/cainjection_in_assumerolepolicies.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/cainjection_in_groups.yaml
+++ b/config/crd/patches/cainjection_in_groups.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/cainjection_in_policies.yaml
+++ b/config/crd/patches/cainjection_in_policies.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/cainjection_in_policyattachments.yaml
+++ b/config/crd/patches/cainjection_in_policyattachments.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/cainjection_in_roles.yaml
+++ b/config/crd/patches/cainjection_in_roles.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/cainjection_in_users.yaml
+++ b/config/crd/patches/cainjection_in_users.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/webhook_in_assumerolepolicies.yaml
+++ b/config/crd/patches/webhook_in_assumerolepolicies.yaml
@@ -1,17 +1,18 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: assumerolepolicies.iam.redradrat.xyz
 spec:
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      clientConfig:
+        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_groups.yaml
+++ b/config/crd/patches/webhook_in_groups.yaml
@@ -1,17 +1,18 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: groups.aws-iam.redradrat.xyz
 spec:
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      clientConfig:
+        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_policies.yaml
+++ b/config/crd/patches/webhook_in_policies.yaml
@@ -1,17 +1,18 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: policies.aws-iam.redradrat.xyz
 spec:
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      clientConfig:
+        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_policyattachments.yaml
+++ b/config/crd/patches/webhook_in_policyattachments.yaml
@@ -1,17 +1,18 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: policyattachments.iam.redradrat.xyz
 spec:
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      clientConfig:
+        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_roles.yaml
+++ b/config/crd/patches/webhook_in_roles.yaml
@@ -1,17 +1,18 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: roles.aws-iam.redradrat.xyz
 spec:
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      clientConfig:
+        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_users.yaml
+++ b/config/crd/patches/webhook_in_users.yaml
@@ -1,17 +1,18 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: users.aws-iam.redradrat.xyz
 spec:
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      clientConfig:
+        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader


### PR DESCRIPTION
Your operator does not run on k8s 1.22, as CRD is no longer supported in v1beta1.  The updates I made for the api update does allow your operator to run on v1.22 for me.

Note, merging this would remove support for k8s < 1.16, as that is when CRD became available in apiextensions.k8s.io/v1.