### PR TITLE
Fix race in the generator for RBAC permission

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -56,6 +56,13 @@ rules:
 - apiGroups:
   - aws-iam.redradrat.xyz
   resources:
+  - assumerolepolicies/finalizers
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - aws-iam.redradrat.xyz
+  resources:
   - assumerolepolicies/status
   verbs:
   - get
@@ -73,6 +80,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - aws-iam.redradrat.xyz
+  resources:
+  - groups/finalizers
+  verbs:
+  - get
+  - update
 - apiGroups:
   - aws-iam.redradrat.xyz
   resources:
@@ -96,6 +110,13 @@ rules:
 - apiGroups:
   - aws-iam.redradrat.xyz
   resources:
+  - policies/finalizers
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - aws-iam.redradrat.xyz
+  resources:
   - policies/status
   verbs:
   - get
@@ -106,9 +127,20 @@ rules:
   resources:
   - policyattachments
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
+- apiGroups:
+  - aws-iam.redradrat.xyz
+  resources:
+  - policyattachments/finalizers
+  verbs:
+  - get
+  - update
 - apiGroups:
   - aws-iam.redradrat.xyz
   resources:
@@ -132,6 +164,13 @@ rules:
 - apiGroups:
   - aws-iam.redradrat.xyz
   resources:
+  - roles/finalizers
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - aws-iam.redradrat.xyz
+  resources:
   - roles/status
   verbs:
   - get
@@ -149,6 +188,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - aws-iam.redradrat.xyz
+  resources:
+  - users/finalizers
+  verbs:
+  - get
+  - update
 - apiGroups:
   - aws-iam.redradrat.xyz
   resources:

--- a/controllers/group_controller.go
+++ b/controllers/group_controller.go
@@ -42,10 +42,7 @@ type GroupReconciler struct {
 
 // +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=groups,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=groups/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=policyattachments,verbs=get;list;watch
-// +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=policyattachments/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=users,verbs=get;list;watch
-// +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=users/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=groups/finalizers,verbs=get;update
 
 func (r *GroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("group", req.NamespacedName)

--- a/controllers/policy_controller.go
+++ b/controllers/policy_controller.go
@@ -45,8 +45,7 @@ type PolicyReconciler struct {
 
 // +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=policies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=policies/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=policyattachments,verbs=get;list;watch
-// +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=policyattachments/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=policies/finalizers,verbs=get;update
 
 func (r *PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("policy", req.NamespacedName)

--- a/controllers/policyattachment_controller.go
+++ b/controllers/policyattachment_controller.go
@@ -46,6 +46,8 @@ type PolicyAttachmentReconciler struct {
 // Reconcile PolicyAttachment
 // +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=policyattachments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=policyattachments/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=policyattachments/finalizers,verbs=get;update
+
 func (r *PolicyAttachmentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("policyattachment", req.NamespacedName)
 

--- a/controllers/role_controller.go
+++ b/controllers/role_controller.go
@@ -50,10 +50,12 @@ type RoleReconciler struct {
 
 // +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=roles,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=roles/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=policyattachments,verbs=get;list;watch
-// +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=policyattachments/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=roles/finalizers,verbs=get;update
+
 // +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=assumerolepolicies,verbs=get;list;watch
 // +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=assumerolepolicies/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=assumerolepolicies/finalizers,verbs=get;update
+
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets/status,verbs=get;update;patch
 

--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -54,10 +54,11 @@ type UserReconciler struct {
 
 // +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=users,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=users/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=policyattachments,verbs=get;list;watch
-// +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=policyattachments/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=aws-iam.redradrat.xyz,resources=users/finalizers,verbs=get;update
+
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets/status,verbs=get;update;patch
+
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=serviceaccounts/status,verbs=get;update;patch
 


### PR DESCRIPTION
1. Fix race in the generator for RBAC permission
2. Add permissions for reading/writing finalizers

Due to the `policyattachments` rbac permissions mentioned several times in multiple controllers, the generator had a race in generating the `config/rbac/role.yaml`